### PR TITLE
add BlockComment & LineComment support for ptxLexer

### DIFF
--- a/src/ptxLexer.g4
+++ b/src/ptxLexer.g4
@@ -277,3 +277,7 @@ fragment
 DIGIT: [0-9] ; 
 
 WS: [ \t\r\n]+ -> skip ;
+
+BlockComment: '/*' .*? '*/' -> skip ;
+
+LineComment: '//' ~[\r\n]* -> skip ;


### PR DESCRIPTION
nvcc 和 clang 默认导出的 ptx 都有注释，在 lexer 里面增加跳过注释的部分。顺带一提，倒是可以把这一套语法提交到 antlr/grammars-v4 仓库…